### PR TITLE
Fix for endianess errors in tests on sparc,powerpc,armel

### DIFF
--- a/test/modp_b64_test.c
+++ b/test/modp_b64_test.c
@@ -20,7 +20,7 @@ static char* testEndian(void)
 {
     /* this test that "1" is "AAAB" */
     char buf[100];
-    char result[10];
+    unsigned char result[10];
     char endian[] = {(char)0, (char)0, (char)1};
     size_t d = modp_b64_encode(buf, endian, (size_t)3);
     mu_assert_int_equals(4, d);
@@ -35,7 +35,7 @@ static char* testEndian(void)
     mu_assert_int_equals(0, result[0]);
     mu_assert_int_equals(0, result[1]);
     mu_assert_int_equals(1, result[2]);
-    mu_assert_int_equals(-1, result[3]);
+    mu_assert_int_equals(255, result[3]);
 
     return 0;
 }
@@ -74,7 +74,7 @@ static char* testPadding(void)
     char msg[100];
     const char ibuf[6] = {1,1,1,1,1,1};
     char obuf[10];
-    char rbuf[10];
+    unsigned char rbuf[10];
     size_t d = 0;
 
     /* 1 in, 4 out */
@@ -87,7 +87,7 @@ static char* testPadding(void)
     d = modp_b64_decode(rbuf, obuf, d);
     mu_assert_int_equals_msg(msg, 1, d);
     mu_assert_int_equals(1, rbuf[0]);
-    mu_assert_int_equals(-1, rbuf[1]);
+    mu_assert_int_equals(255, rbuf[1]);
 
     /* 2 in, 4 out */
     memset(obuf, 255, sizeof(obuf));
@@ -100,7 +100,7 @@ static char* testPadding(void)
     mu_assert_int_equals_msg(msg, 2, d);
     mu_assert_int_equals_msg(msg, 1, rbuf[0]);
     mu_assert_int_equals_msg(msg, 1, rbuf[1]);
-    mu_assert_int_equals_msg(msg, -1, rbuf[2]);
+    mu_assert_int_equals_msg(msg, 255, rbuf[2]);
 
     /* 3 in, 4 out */
     memset(obuf, 255, sizeof(obuf));
@@ -114,7 +114,7 @@ static char* testPadding(void)
     mu_assert_int_equals_msg(msg, 1, rbuf[0]);
     mu_assert_int_equals_msg(msg, 1, rbuf[1]);
     mu_assert_int_equals_msg(msg, 1, rbuf[2]);
-    mu_assert_int_equals_msg(msg, -1, rbuf[3]);
+    mu_assert_int_equals_msg(msg, 255, rbuf[3]);
 
     /* 4 in, 8 out */
     memset(obuf, 255, sizeof(obuf));
@@ -129,7 +129,7 @@ static char* testPadding(void)
     mu_assert_int_equals(1, rbuf[1]);
     mu_assert_int_equals(1, rbuf[2]);
     mu_assert_int_equals(1, rbuf[3]);
-    mu_assert_int_equals(-1, rbuf[4]);
+    mu_assert_int_equals(255, rbuf[4]);
 
     /* 5 in, 8 out */
     memset(obuf, 255, sizeof(obuf));
@@ -145,7 +145,7 @@ static char* testPadding(void)
     mu_assert_int_equals(1, rbuf[2]);
     mu_assert_int_equals(1, rbuf[3]);
     mu_assert_int_equals(1, rbuf[4]);
-    mu_assert_int_equals(-1, rbuf[5]);
+    mu_assert_int_equals(255, rbuf[5]);
 
     /* 6 in, 8 out */
     memset(obuf, 255, sizeof(obuf));
@@ -162,7 +162,7 @@ static char* testPadding(void)
     mu_assert_int_equals(1, rbuf[3]);
     mu_assert_int_equals(1, rbuf[4]);
     mu_assert_int_equals(1, rbuf[5]);
-    mu_assert_int_equals(-1, rbuf[6]);
+    mu_assert_int_equals(255, rbuf[6]);
 
     return 0;
 }

--- a/test/modp_b85_test.c
+++ b/test/modp_b85_test.c
@@ -21,7 +21,7 @@ static char* testEndian(void)
 {
     /* this test that "1" is "!!!!#" */
     char buf[100];
-    char result[10];
+    unsigned char result[10];
     char endian[] = {(char)0, (char)0, (char)0, (char)1};
     size_t d = modp_b85_encode(buf, endian, (size_t)4);
     mu_assert_int_equals(5, d);
@@ -38,7 +38,7 @@ static char* testEndian(void)
     mu_assert_int_equals(0, result[1]);
     mu_assert_int_equals(0, result[2]);
     mu_assert_int_equals(1, result[3]);
-    mu_assert_int_equals(-1, result[4]);
+    mu_assert_int_equals(255, result[4]);
 
     return 0;
 }
@@ -88,9 +88,9 @@ static char* testBadCharDecode(void)
 
 static char* testEncodeDecode(void)
 {
-    char ibuf[10]; /* input */
-    char obuf[10]; /* output */
-    char rbuf[10]; /* final result */
+    unsigned char ibuf[10]; /* input */
+    unsigned char obuf[10]; /* output */
+    unsigned char rbuf[10]; /* final result */
     size_t d;
     int i,j,k,l;
     for (i = 0; i < 256; ++i) {
@@ -112,7 +112,7 @@ static char* testEncodeDecode(void)
                     mu_assert_int_equals(ibuf[1], rbuf[1]);
                     mu_assert_int_equals(ibuf[2], rbuf[2]);
                     mu_assert_int_equals(ibuf[3], rbuf[3]);
-                    mu_assert_int_equals(-1, rbuf[4]);
+                    mu_assert_int_equals(255, rbuf[4]);
                 }
             }
         }


### PR DESCRIPTION
This is the patch from #32. Just as a pull request. I'm trying to reduce the amount of patches in my debian packages.