### PR TITLE
Add pkgconfig file to build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,7 @@ AC_CONFIG_FILES([
 	Makefile
 	src/Makefile
 	test/Makefile
+	src/stringencoders.pc
 ])
 AC_PROG_MAKE_SET
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,6 +24,9 @@ libmodpbase64_la_SOURCES = \
 	modp_json.h modp_json.c \
 	modp_messagepack.h modp_messagepack.c
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = stringencoders.pc
+
 #libmodpbase64_la_DEPENDENCIES = \
 #	modp_b2_data.h modp_b2_gen \
 #	modp_b16_data.h modp_b16_gen \

--- a/src/stringencoders.pc.in
+++ b/src/stringencoders.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: stringencoders
+Description:  collection of high performance c-string transformations
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lmodpbase64
+Cflags: -I${includedir}


### PR DESCRIPTION
Another patch I added in debian. Adds a pkgconfig file so it's easier to include the library in projects etc.