### PR TITLE
Include extern_c_begin.h and extern_c_end.h in output

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,6 @@
 
 include_HEADERS = \
+	extern_c_begin.h extern_c_end.h \
 	modp_b16.h modp_b64.h modp_b64w.h modp_b64r.h \
 	modp_b85.h modp_burl.h modp_bjavascript.h \
 	modp_numtoa.h modp_ascii.h modp_b2.h \


### PR DESCRIPTION
Hi, extern_c_begin.h and extern_c_end.h are not included in the $PREFIX/include directory, which causes problems if using the include dir directly.