### PR TITLE
fix compiling with GCC 7

### DIFF
--- a/src/modp_ascii.c
+++ b/src/modp_ascii.c
@@ -40,10 +40,13 @@ void modp_toupper_copy(char* dest, const char* str, size_t len)
     switch (leftover) {
     case 3:
         *dest++ = (char)gsToUpperMap[ustr[i++]];
+        /* fall through */
     case 2:
         *dest++ = (char)gsToUpperMap[ustr[i++]];
+        /* fall through */
     case 1:
         *dest++ = (char)gsToUpperMap[ustr[i]];
+        /* fall through */
     case 0:
         *dest = '\0';
     }
@@ -75,10 +78,13 @@ void modp_tolower_copy(char* dest, const char* str, size_t len)
     switch (leftover) {
     case 3:
         *dest++ = (char)gsToLowerMap[ustr[i++]];
+        /* fall through */
     case 2:
         *dest++ = (char)gsToLowerMap[ustr[i++]];
+        /* fall through */
     case 1:
         *dest++ = (char)gsToLowerMap[ustr[i]];
+        /* fall through */
     case 0:
         *dest = '\0';
     }
@@ -121,10 +127,13 @@ void modp_toprint_copy(char* dest, const char* str, size_t len)
     switch (leftover) {
     case 3:
         *dest++ = (char)gsToPrintMap[s[i++]];
+        /* fall through */
     case 2:
         *dest++ = (char)gsToPrintMap[s[i++]];
+        /* fall through */
     case 1:
         *dest++ = (char)gsToPrintMap[s[i]];
+        /* fall through */
     case 0:
         *dest = '\0';
     }

--- a/test/speedtest_numtoa.c
+++ b/test/speedtest_numtoa.c
@@ -2,7 +2,7 @@
  * trick gcc to accepting snprintf which is a C99-ism
  */
 #define _ISOC99_SOURCE
-#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #define _XOPEN_SOURCE 500
 #define _POSIX_C_SOURCE 200112L
 #include <stdint.h>


### PR DESCRIPTION
Fix two issues below:
error: this statement may fall through [-Werror=implicit-fallthrough=]
error: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Werror=cpp]