### PR TITLE
Added 3 fuzzers

### DIFF
--- a/test/fuzz/modp_toupper_fuzzer.c
+++ b/test/fuzz/modp_toupper_fuzzer.c
@@ -1,0 +1,23 @@
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "modp_ascii.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+        if(size<3){
+                return 0;
+        }
+
+        char *new_str = (char *)malloc(size+1);
+        if (new_str == NULL){
+                return 0;
+        }
+        memcpy(new_str, data, size);
+        new_str[size] = '\0';
+
+        modp_toupper(new_str, size);
+
+        free(new_str);
+        return 1;
+}

--- a/test/fuzz/modp_utf8_validate_fuzzer.c
+++ b/test/fuzz/modp_utf8_validate_fuzzer.c
@@ -1,0 +1,23 @@
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "modp_utf8.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+        if(size<3){
+                return 0;
+        }
+
+        char *new_str = (char *)malloc(size+1);
+        if (new_str == NULL){
+                return 0;
+        }
+        memcpy(new_str, data, size);
+        new_str[size] = '\0';
+
+        modp_utf8_validate(new_str, size);
+
+        free(new_str);
+        return 1;
+}

--- a/test/fuzz/modp_xml_decode_fuzzer3.c
+++ b/test/fuzz/modp_xml_decode_fuzzer3.c
@@ -1,0 +1,17 @@
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "modp_xml.h"
+
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+        if(size<3){
+                return 0;
+        }
+
+        size_t d = 0;
+        char buf[size+1];
+        d = modp_xml_decode(buf, (char*)data, size);
+        return 1;
+}


### PR DESCRIPTION
This PR adds 3 fuzzers.

Since stringencoders is a security-critical library for Chromium, it might be worth it to integrate it into oss-fuzz to setup continuous fuzzing. I can confirm that these 3 fuzzers run on their infrastructure.

oss-fuzz is a free service, however it is expected that the found bugs are fixed, so Googles resources are well spent.

I will be happy to setup continuous integration of stringencoders.

If there aren't resources to fix the bugs found by the fuzzers, we may ask Google if they are interested in fuzzing the library anyway, as they currently use it. In this case, it would be helpful to have the fuzzers on the upstream repository as well.